### PR TITLE
ci: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/postgres
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -72,6 +75,9 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false # Don't cancel other tests if one fails
       matrix:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -21,6 +21,9 @@ env:
   REGISTRY: ghcr.io
   HELM_REGISTRY: oci://ghcr.io/flanksource/charts
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -91,6 +94,9 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/postgres
 
+permissions:
+  contents: read
+
 jobs:
   determine-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ env:
   TEST_USER: testuser
   TEST_PASSWORD: testpass123
 
+permissions:
+  contents: read
+
 jobs:
   test-env-variables:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves the 7 open CodeQL **"Workflow does not contain permissions"** (Medium) code scanning alerts across all four GitHub Actions workflows.

Each workflow now declares a restrictive top-level `permissions: contents: read` default, following the principle of least privilege. The `GITHUB_TOKEN` in jobs that don't need write access is now scoped to read-only, rather than inheriting the repository/organization default (which is often read-write).

## Changes

| Workflow | Fix |
|----------|-----|
| `build-and-test.yml` | Top-level `contents: read`; `test` job granted `packages: read` (needs to `docker pull` the image from ghcr.io) |
| `test.yml` | Top-level `contents: read` (covers `test-env-variables` and `test-builds`) |
| `helm.yml` | Top-level `contents: read`; `security-scan` job granted `security-events: write` (needs to upload the Checkov SARIF results) |
| `release.yml` | Top-level `contents: read` (covers `build-images-for-version-detection` and `get-postgres-versions`) |

Jobs that already declared their own `permissions` blocks (e.g. `packages: write`, `contents: write` for pushing images, tags, and releases) are left unchanged — a top-level default only applies to jobs that don't specify their own.

## Verification

- All four workflow files validated with `yaml.safe_load`.
- Reviewed each job's steps to confirm the granted scopes match what the job actually does (checkout, pull/push images, upload SARIF, push tags/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7v75WdVmg6AFyTWCpWjX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7v75WdVmg6AFyTWCpWjX1)_